### PR TITLE
bugfix/classname-className

### DIFF
--- a/includes/Block/CoreGallery.php
+++ b/includes/Block/CoreGallery.php
@@ -84,7 +84,7 @@ class CoreGallery extends BlockBase {
 						'url'        => $image['url'] ?? '',
 						'alt'        => $image['alt'] ?? '',
 						'figcaption' => $image['caption'] ?? '',
-						'classname'  => self::$item_block_classname,
+						'className'  => self::$item_block_classname,
 					],
 				]
 			);


### PR DESCRIPTION
- fixes classname generation on image block getting created as well as className (camelcase)
- this has been tested and fixes the potential cascading affect outlined in https://github.com/AEWP/php-block-builders/issues/19